### PR TITLE
Fixed generation of UIFont duplicates

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -38,21 +38,25 @@ export function cgColor(color, project, useColorNames) {
 }
 
 export function generateFontExtension(textStyles) {
-  let fontsString = '';
-  textStyles.forEach(style => {
-    fontsString += `${' '.repeat(4)}static func ${camelize(
-      style.fontFace
-    )}(ofSize: CGFloat) -> UIFont {\n\n`;
-    fontsString += `${' '.repeat(8)}return UIFont(name: "${
-      style.fontFace
-    }", size: size)!\n`;
-    fontsString += `${' '.repeat(4)}}\n`;
+  const uniqueFonts = Array.from(
+    new Set(textStyles.map(style => style.fontFace))
+  ).sort();
+
+  const fonfacesFunctions = uniqueFonts.map(styleName => {
+    let result = '';
+    result += `${' '.repeat(4)}static func ${camelize(
+      styleName
+    )}(ofSize: CGFloat) -> UIFont {\n`;
+    result += `${' '.repeat(8)}`;
+    result += `return UIFont(name: "${styleName}", size: size)!\n`;
+    result += `${' '.repeat(4)}}`;
+    return result;
   });
 
   let string = 'import UIKit\n\n';
   string += 'extension UIFont {\n';
-  string += fontsString;
-  string += '}';
+  string += fonfacesFunctions.join('\n');
+  string += '\n}';
 
   return {
     code: string,


### PR DESCRIPTION
For Zeplin projects with stylesheet containing the same font in different styles, current realization generates a copy of UIFont function for each style, generating lot's of duplicates

![image](https://user-images.githubusercontent.com/8275916/36947710-565019e8-2002-11e8-9248-1c186270d6cf.png)

The PR takes only unique fontfaces.