### PR TITLE
WIP: added option for gradient class selection

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -64,10 +64,16 @@ export function generateFontExtension(textStyles) {
 export function options(context) {
   return {
     useColorNames: context.getOption('use_color_names'),
+    linearGradientClassName: context.getOption('linear_gradient_class_name'),
   };
 }
 
-export function linearGradientLayer(gradient, project, useColorNames) {
+export function linearGradientLayer(
+  gradient,
+  project,
+  useColorNames,
+  gradientClassName
+) {
   let colorStopsString = '';
   let colorStopsPositionString = '';
   const { colorStops } = gradient;
@@ -81,7 +87,7 @@ export function linearGradientLayer(gradient, project, useColorNames) {
     colorStopsPositionString += `${colorStop.position}${divideString}`;
   });
 
-  let string = 'let gradientLayer = CAGradientLayer()\n';
+  let string = `let gradientLayer = ${gradientClassName}()\n`;
   string += 'gradientLayer.frame = view.bounds\n';
   if (gradient.angle === 90) {
     string += 'gradientLayer.startPoint = CGPoint(x: 0.0, y: 0.5)\n';

--- a/src/index.js
+++ b/src/index.js
@@ -17,12 +17,17 @@ export function styleguideTextStyles(context, textStyles) {
 
 export function layer(context, layerParams) {
   let string = '';
-  const { useColorNames } = options(context);
+  const { useColorNames, linearGradientClassName } = options(context);
   const { gradient } = layerParams.fills[0];
   if (gradient !== undefined) {
     switch (gradient.type) {
       case 'linear':
-        string += linearGradientLayer(gradient, context.project, useColorNames);
+        string += linearGradientLayer(
+          gradient,
+          context.project,
+          useColorNames,
+          linearGradientClassName
+        );
         break;
       case 'radial':
         string += radialGradientLayer(gradient, context.project, useColorNames);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,6 +15,12 @@
       "type": "switch",
       "id": "use_color_names",
       "default": true
+    },
+    {
+      "name": "Linear gradient class name",
+      "type": "text",
+      "id": "linear_gradient_class_name",
+      "default": "CAGradientLayer"
     }
   ]
 }


### PR DESCRIPTION
Discussion started: #1 

My example requires some refinement. Current realization doesn't support animating gradient's properties, so it's suitable only for static views.

Also, it's not very clear to me, how can we pass this `CALayer` subclass into generated code without overcomplicating it.

My proposal is:
* Add a possibility to specify linear gradient class name, by adding the parameter in options (Done)
* add a playground demonstrating sample usage (Todo)
* Update readme with links and motivation (Todo)

What do you think?